### PR TITLE
Update LMCircularScrollingFlowLayout.m

### DIFF
--- a/Pod/Classes/LMCircularScrollingFlowLayout.m
+++ b/Pod/Classes/LMCircularScrollingFlowLayout.m
@@ -39,7 +39,7 @@
         if (self.collectionView.contentOffset.y <= 0.0f) {
             [self.collectionView setContentOffset:CGPointMake(self.collectionView.contentOffset.x, [super collectionViewContentSize].height + self.minimumLineSpacing)];
         }
-        else if (self.collectionView.contentOffset.y >= [super collectionViewContentSize].height + self.minimumLineSpacing) {
+        else if (self.collectionView.contentOffset.y > [super collectionViewContentSize].height + self.minimumLineSpacing) {
             [self.collectionView setContentOffset:CGPointMake(self.collectionView.contentOffset.x, 0.0f)];
         }
     }
@@ -47,7 +47,7 @@
         if (self.collectionView.contentOffset.x <= 0.0f) {
             [self.collectionView setContentOffset:CGPointMake([super collectionViewContentSize].width + self.minimumLineSpacing, self.collectionView.contentOffset.y)];
         }
-        else if (self.collectionView.contentOffset.x >= [super collectionViewContentSize].width + self.minimumLineSpacing) {
+        else if (self.collectionView.contentOffset.x > [super collectionViewContentSize].width + self.minimumLineSpacing) {
             [self.collectionView setContentOffset:CGPointMake(0.0f, self.collectionView.contentOffset.y)];
         }
     }


### PR DESCRIPTION
fix a bug that content offset changes like toggle between contentSize.width or zero if minimumLineSpacing is zero.
